### PR TITLE
feat: add example package configuration with checksum included

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,6 +2,7 @@ defmodule RustlerPrecompilationExample.MixProject do
   use Mix.Project
 
   @version "0.4.0"
+  @source_url "https://github.com/philss/rustler_precompilation_example"
 
   def project do
     [
@@ -9,7 +10,29 @@ defmodule RustlerPrecompilationExample.MixProject do
       version: @version,
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
+      description: "A rustler precomplication example",
+      package: package(),
       deps: deps()
+    ]
+  end
+
+  # When publishing a library to with precompiled NIFs to Hex,
+  # is is mandatory to include a checksum file (along with other
+  # necessary files in the library).
+  #
+  # Refer to the "The release flow"
+  # in the "Precompilation guide" for more details:
+  # https://hexdocs.pm/rustler_precompiled/precompilation_guide.html#the-release-flow
+  defp package do
+    [
+      files: [
+        "lib",
+        "native",
+        "checksum-*.exs",
+        "mix.exs"
+      ],
+      licenses: ["Apache-2.0"],
+      links: %{"GitHub" => @source_url}
     ]
   end
 


### PR DESCRIPTION
I thought it would be useful to include example configuration for the checksum file for clarification. Refer to [this issue](https://github.com/philss/rustler_precompiled/issues/15) for more details.  In my opinion the main use-case for Rustler Precompiled is for libraries, so including the configuration necessary to publish it on Hex fits within the scope of the example. 

## Notes

* in order for `mix hex.build --unpack` to pass, a license is required. I used the same license as Rustler Precompiled

## Instructions

1. run: `mix rustler_precompiled.download RustlerPrecompilationExample.Native --only-local` to generate checksum file

2. run `mix hex.build --unpack` to check which files will be included in the package. 

```
rustler_precompilation_example ~ mix hex.build --unpack
Building rustler_precompilation_example 0.4.0
  Dependencies:
    rustler_precompiled ~> 0.4 (app: rustler_precompiled)
    rustler >= 0.0.0 (app: rustler) (optional)
  App: rustler_precompilation_example
  Name: rustler_precompilation_example
  Files:
    lib
    lib/rustler_precompilation_example.ex
    lib/rustler_precompilation_example
    lib/rustler_precompilation_example/native.ex
    native
    native/example
    native/example/Cargo.toml
    native/example/Cargo.lock
    native/example/README.md
    native/example/.cargo
    native/example/.cargo/config
    native/example/.gitignore
    native/example/src
    native/example/src/lib.rs
    checksum-Elixir.RustlerPrecompilationExample.Native.exs
    mix.exs
  Version: 0.4.0
  Build tools: mix
  Description: A rustler precomplication example
  Licenses: Apache-2.0
  Links:
    GitHub: https://github.com/philss/rustler_precompilation_example
  Elixir: ~> 1.12
Saved to rustler_precompilation_example-0.4.0
```
