### PR TITLE
fix warnings in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' ../../mix.exs | head -n1)" >> $GITHUB_ENV
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
         target: ${{ matrix.job.target }}


### PR DESCRIPTION
The release workflow uses actions-rs/toolchain@v1 which seems to be unmaintained and accumulated some warnings (see https://github.com/actions-rs/toolchain/issues/216). 

[`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) seems to be a commonly used replacement (which I base my personal rust build upon now).