### PR TITLE
Fixed deprecated release workflow commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,8 +141,8 @@ jobs:
         LIB_FINAL_PATH="${NIF_DIRECTORY}/${LIB_FINAL_NAME}.tar.gz"
 
         # Let subsequent steps know where to find the lib
-        echo ::set-output name=LIB_FINAL_PATH::${LIB_FINAL_PATH}
-        echo ::set-output name=LIB_FINAL_NAME::${LIB_FINAL_NAME}.tar.gz
+        echo "LIB_FINAL_PATH=${{ LIB_FINAL_PATH }}" >> $GITHUB_OUTPUT
+        echo "LIB_FINAL_NAME=${{ LIB_FINAL_NAME }}.tar.gz" >> $GITHUB_OUTPUT
 
     - name: "Artifact upload"
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,8 +141,8 @@ jobs:
         LIB_FINAL_PATH="${NIF_DIRECTORY}/${LIB_FINAL_NAME}.tar.gz"
 
         # Let subsequent steps know where to find the lib
-        echo "LIB_FINAL_PATH=${{ LIB_FINAL_PATH }}" >> $GITHUB_OUTPUT
-        echo "LIB_FINAL_NAME=${{ LIB_FINAL_NAME }}.tar.gz" >> $GITHUB_OUTPUT
+        echo "LIB_FINAL_PATH=${LIB_FINAL_PATH}" >> $GITHUB_OUTPUT
+        echo "LIB_FINAL_NAME=${LIB_FINAL_NAME}.tar.gz" >> $GITHUB_OUTPUT
 
     - name: "Artifact upload"
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,6 @@ jobs:
       with:
         toolchain: stable
         target: ${{ matrix.job.target }}
-        override: true
-        profile: minimal
 
     - name: Show version information (Rust, cargo, GCC)
       shell: bash
@@ -145,7 +143,7 @@ jobs:
         echo "LIB_FINAL_NAME=${LIB_FINAL_NAME}.tar.gz" >> $GITHUB_OUTPUT
 
     - name: "Artifact upload"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.rename.outputs.LIB_FINAL_NAME }}
         path: ${{ steps.rename.outputs.LIB_FINAL_PATH }}


### PR DESCRIPTION
I spotted one more deprecation warning in my project and want to share the fix :)

GitHub deprecated the `set-output` command as it is used in our release workflow:

```
run: echo "::set-output name={name}::{value}"
```

The updated way to set outputs is

```
run: echo "{name}={value}" >> $GITHUB_OUTPUT
```

see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/