### PR TITLE
CI: update macOS runner to 12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , use-cross: true }
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , use-cross: true }
           - { target: aarch64-unknown-linux-musl  , os: ubuntu-20.04 , use-cross: true }
-          - { target: aarch64-apple-darwin        , os: macos-11      }
+          - { target: aarch64-apple-darwin        , os: macos-12      }
           - { target: riscv64gc-unknown-linux-gnu , os: ubuntu-20.04 , use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-11      }
+          - { target: x86_64-apple-darwin         , os: macos-12      }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04  }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , use-cross: true }
           - { target: x86_64-pc-windows-gnu       , os: windows-2019  }


### PR DESCRIPTION
I notice that gh action does no longer support macOS 11 while trying to publish my nif
https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/